### PR TITLE
Introduce Mathfield component

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "asciimath2tex": "^1.1.0",
     "clsx": "^1.1.1",
     "katex": "^0.13.1",
+    "mathlive": "^0.65.0",
     "nearley": "^2.20.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-math-view": "^1.2.0",
     "react-router-dom": "^5.2.0",
     "react-table": "^7.6.3"
   },
@@ -69,7 +69,6 @@
     "create-ts-index": "^1.13.6",
     "husky": "^4",
     "lint-staged": "^10.5.4",
-    "mathlive": "^0.59.0",
     "prettier": "^2.2.1",
     "react-scripts": "4.0.3",
     "typescript": "^4.2.3"

--- a/src/components/Mathfield/Mathfield.tsx
+++ b/src/components/Mathfield/Mathfield.tsx
@@ -1,0 +1,103 @@
+import type { MathfieldElement } from "mathlive"
+import type { MathfieldOptions } from "mathlive/dist/public/options"
+import "mathlive/dist/mathlive-fonts.css"
+import "mathlive/dist/mathlive.min"
+import { forwardRef, PropsWithChildren, useEffect, useImperativeHandle, useMemo, useRef, memo } from "react"
+import { createStyles, makeStyles } from "@material-ui/core"
+import clsx from "clsx"
+
+declare global {
+  /** @internal */
+  namespace JSX {
+    interface IntrinsicElements {
+      "math-field": React.DetailedHTMLProps<React.HTMLAttributes<MathfieldElement>, MathfieldElement>
+    }
+  }
+}
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    mathfield: {
+      borderColor: theme.palette.divider,
+      borderWidth: 2,
+      borderStyle: "solid",
+      padding: "8px",
+      fontSize: "32px",
+      textAlign: "center",
+      "&:focus-within": {
+        borderColor: theme.palette.primary.main
+      },
+      // Mathlive specific styles (https://cortexjs.io/mathlive/guides/customizing/)
+      "--hue": `204 !important`,
+      "--highlight": `${theme.palette.action.selected} !important`,
+      "--highlight-inactive": `${theme.palette.action.disabled} !important`,
+      "--caret": `${theme.palette.primary.light} !important`,
+      "--primary": `${theme.palette.primary.light} !important`
+    }
+  })
+)
+
+type MathfieldProps = PropsWithChildren<{
+  value?: string
+  className?: string
+  options?: Partial<MathfieldOptions>
+  onEnter?: () => void
+}>
+
+const baseOptions: Partial<MathfieldOptions> = {
+  defaultMode: "math",
+  smartMode: false,
+  smartFence: false,
+  plonkSound: null,
+  keypressSound: null,
+  macros: {},
+  inlineShortcuts: {}
+}
+
+export const Mathfield = memo(
+  forwardRef<MathfieldElement, MathfieldProps>(({ value, className, options, onEnter }, ref) => {
+    const classes = useStyles()
+    const internalRef = useRef<MathfieldElement>(null)
+    useImperativeHandle(ref, () => internalRef.current!, [internalRef])
+
+    const mathfieldOptions: Partial<MathfieldOptions> = useMemo(() => {
+      return { ...baseOptions, ...options }
+    }, [options])
+    useEffect(() => {
+      internalRef.current?.setOptions(mathfieldOptions)
+    }, [mathfieldOptions])
+
+    // Apply onKeystroke option (This is seperate because we don't want other settings overwritten when onEnter changes)
+    useEffect(() => {
+      const mathfield = internalRef.current
+      if (mathfield && onEnter) {
+        mathfield.setOptions({
+          onKeystroke: (_sender, _keystroke, e) => {
+            if (e.code === "Enter" && mathfield.mode !== "latex") {
+              onEnter()
+              return false
+            }
+            return true
+          }
+        })
+      }
+    }, [onEnter])
+
+    useEffect(() => {
+      internalRef.current?.setValue(value)
+    }, [value])
+
+    return (
+      <div className={clsx(classes.mathfield, className)}>
+        <math-field
+          ref={internalRef}
+          style={{
+            outline: "none"
+          }}
+        >
+          {value}
+        </math-field>
+      </div>
+    )
+  })
+)

--- a/src/components/Mathfield/index.ts
+++ b/src/components/Mathfield/index.ts
@@ -1,0 +1,1 @@
+export * from "./Mathfield"

--- a/src/pages/TruthTable.tsx
+++ b/src/pages/TruthTable.tsx
@@ -1,31 +1,27 @@
+import type { MathfieldElement } from "mathlive"
 import type { MathfieldOptions } from "mathlive/dist/public/options"
 import { Button, createStyles, Divider, Grid, makeStyles, Typography } from "@material-ui/core"
 import { useCallback, useEffect, useRef, useState } from "react"
-import MathView, { MathViewRef } from "react-math-view"
 import { useParams } from "react-router-dom"
 import TeX from "@matejmazur/react-katex"
 import { LatexTable } from "../components/LatexTable"
 import { Notification } from "../components/Notification"
 import { buildTable } from "../util/buildTable"
 import { Column } from "react-table"
-import { MathfieldElement } from "mathlive"
-import { useMathfieldOptions } from "../util/hooks/useMathfieldOptions"
+import { Mathfield } from "../components/Mathfield"
 
 const useStyles = makeStyles((theme) =>
   createStyles({
     gridRoot: {
       paddingTop: 10,
-      paddingBottom: 30
+      paddingBottom: 10
     },
     mathfield: {
       minWidth: "25%",
-      maxWidth: "50%",
-      fontSize: "32px",
-      textAlign: "center",
-      padding: "8px",
-      borderWidth: 2,
-      borderStyle: "solid",
-      borderColor: theme.palette.divider
+      maxWidth: "50%"
+    },
+    buttonContainer: {
+      paddingTop: 10
     },
     button: {
       paddingLeft: "10px"
@@ -36,55 +32,37 @@ const useStyles = makeStyles((theme) =>
     help: {
       justifyContent: "center",
       textAlign: "center",
-      paddingBottom: 20
+      paddingBottom: 10
     }
   })
 )
 
+const mathfieldOptions: Partial<MathfieldOptions> = {
+  inlineShortcuts: {
+    "->": "\\to",
+    "<->": "\\leftrightarrow",
+    iff: "\\leftrightarrow",
+    if: "\\to",
+    implies: "\\to",
+    to: "\\to",
+    not: "\\neg",
+    and: "\\wedge",
+    or: "\\vee",
+    xor: "\\oplus"
+  }
+}
+
 const TruthTable = () => {
   const { initialValue } = useParams<{ initialValue?: string }>()
   const classes = useStyles()
-  const mathfieldRef = useRef<MathViewRef>(null)
+  const mathfieldRef = useRef<MathfieldElement>(null)
   const [value, setValue] = useState<string>(initialValue ? initialValue : "r→q")
 
   const process = useCallback(() => {
     if (mathfieldRef.current) {
-      setValue(mathfieldRef.current.getValue("ASCIIMath"))
+      setValue(mathfieldRef.current.getValue("ascii-math"))
     }
   }, [mathfieldRef])
-
-  const mathfieldOptions = useCallback(
-    (mathfield: MathfieldElement): Partial<MathfieldOptions> => {
-      return {
-        defaultMode: "math",
-        smartMode: false,
-        smartFence: false,
-        macros: {},
-        inlineShortcuts: {
-          "->": "\\to",
-          "<->": "\\leftrightarrow",
-          iff: "\\leftrightarrow",
-          if: "\\to",
-          implies: "\\to",
-          to: "\\to",
-          not: "\\neg",
-          and: "\\wedge",
-          or: "\\vee",
-          xor: "\\oplus"
-        },
-        onKeystroke: (_sender, _keystroke, e) => {
-          if (e.code === "Enter") {
-            process()
-            return false
-          }
-          return true
-        }
-      }
-    },
-    [process]
-  )
-
-  useMathfieldOptions(mathfieldRef, mathfieldOptions)
 
   const [notificationData, setNotificationData] = useState<{
     message: string
@@ -126,24 +104,41 @@ const TruthTable = () => {
 
   return (
     <>
-      <Grid container justify="center" alignItems="center" alignContent="center" className={classes.gridRoot}>
+      <Grid
+        container
+        direction="column"
+        justify="center"
+        alignItems="center"
+        alignContent="center"
+        className={classes.gridRoot}
+      >
         <Grid item className={classes.mathfield}>
-          <MathView value={value} ref={mathfieldRef} />
+          <Mathfield value={value} options={mathfieldOptions} onEnter={process} ref={mathfieldRef} />
         </Grid>
-        <Grid item className={classes.button}>
-          <Button variant="contained" color="primary" onClick={process}>
-            Go
-          </Button>
-        </Grid>
-        <Grid item className={classes.button}>
-          <Button variant="contained" color="primary" onClick={onShareClick}>
-            Share
-          </Button>
-        </Grid>
-        <Grid item className={classes.button}>
-          <Button variant="contained" color="primary" onClick={toggleHelp}>
-            Help
-          </Button>
+        <Grid
+          container
+          item
+          direction="row"
+          justify="center"
+          alignItems="center"
+          alignContent="center"
+          className={classes.buttonContainer}
+        >
+          <Grid item className={classes.button}>
+            <Button variant="contained" color="primary" onClick={process}>
+              Go
+            </Button>
+          </Grid>
+          <Grid item className={classes.button}>
+            <Button variant="contained" color="primary" onClick={onShareClick}>
+              Share
+            </Button>
+          </Grid>
+          <Grid item className={classes.button}>
+            <Button variant="contained" color="primary" onClick={toggleHelp}>
+              Help
+            </Button>
+          </Grid>
         </Grid>
       </Grid>
       <div className={classes.help} hidden={helpOpen}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,15 +3936,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001157:
-  version "1.0.30001159"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
-  integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001185"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz#3482a407d261da04393e2f0d61eefbc53be43b95"
-  integrity sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001181:
+  version "1.0.30001228"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz"
+  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8064,11 +8059,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8200,10 +8190,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mathlive@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/mathlive/-/mathlive-0.59.0.tgz#95e3720a8c16a295d266c36ddf9d6c8bfc363228"
-  integrity sha512-CUf7kAY1UWTvJm5IFJrFlXssyl851aGPNAdlchMbAMZQnryudQJE59BlrPTtAeY95k41PGqMmM8Vozj+We+hNA==
+mathlive@^0.65.0:
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/mathlive/-/mathlive-0.65.0.tgz#df1d92a40abc0e5561e6bc3085bb42b0eb577cf2"
+  integrity sha512-LyMOYry0prmQ0hP8b1FtDqG4wzYbcQD6yhSewQbWjlVPBlnP/EHV5VBiwIl2HRBGuATEng59w8NmkYCzNvTzgg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -10266,14 +10256,6 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-math-view@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-math-view/-/react-math-view-1.2.0.tgz#f0c37c5ef21a77fece86b1c3883629a49a917462"
-  integrity sha512-+IqHHcdOHIRycztkePKsxcoWUqZtr/tO3pUOvn+QtjnH+ilua5pDUT0Qlo/0ekI6Mv2jUZIU4WWo7oD8kXqV/A==
-  dependencies:
-    lodash.isequal "^4.5.0"
-    mathlive "^0.59.0"
 
 react-refresh@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
This PR moves away from `react-math-view` in favor of a custom `Mathfield` component. Additionally, it updates to the latest mathlive and makes it a production dependency.