### PR TITLE
Port TruthTable parser over to latex

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "asciimath2tex": "^1.1.0",
     "clsx": "^1.1.1",
     "immutable": "^4.0.0-rc.12",
     "katex": "^0.13.11",

--- a/src/pages/TruthTable.tsx
+++ b/src/pages/TruthTable.tsx
@@ -56,17 +56,17 @@ const TruthTable = () => {
   const { initialValue } = useParams<{ initialValue?: string }>()
   const classes = useStyles()
   const mathfieldRef = useRef<MathfieldElement>(null)
-  const [value, setValue] = useState<string>(initialValue || "")
+  const [value, setValue] = useState<string>(initialValue ? decodeURI(initialValue) : "")
   const { triggerNotification } = useNotificationContext()
 
   const process = useCallback(() => {
     if (mathfieldRef.current) {
-      setValue(mathfieldRef.current.getValue("ascii-math"))
+      setValue(mathfieldRef.current.getValue("latex-expanded"))
     }
   }, [mathfieldRef])
 
   const onShareClick = useCallback(() => {
-    window.navigator.clipboard.writeText(`${window.location.protocol}//${window.location.host}/truthtable/${value}`)
+    window.navigator.clipboard.writeText(`${window.location.protocol}//${window.location.host}/truthtable/${encodeURI(value)}`)
     triggerNotification("Share link copied to clipboard!", "info")
   }, [triggerNotification, value])
 
@@ -97,6 +97,11 @@ const TruthTable = () => {
         alignContent="center"
         className={classes.gridRoot}
       >
+        <Grid item>
+          <Typography variant="h6" component="div">
+            Proposition:
+          </Typography>
+        </Grid>
         <Grid item className={classes.mathfield}>
           <Mathfield value={value} options={mathfieldOptions} onSubmit={process} ref={mathfieldRef} />
         </Grid>
@@ -128,35 +133,35 @@ const TruthTable = () => {
       </Grid>
       <div className={classes.help} hidden={helpOpen}>
         <Divider />
-        <Typography variant="h6">Shortcuts:</Typography>
+        <Typography variant="h6" component="div">Shortcuts:</Typography>
         <Grid container alignItems="center" justify="center" spacing={2}>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               not: <TeX>\neg</TeX>
             </Typography>
           </Grid>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               and: <TeX>\wedge</TeX>
             </Typography>
           </Grid>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               or: <TeX>\vee</TeX>
             </Typography>
           </Grid>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               xor: <TeX>\oplus</TeX>
             </Typography>
           </Grid>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               if: <TeX>\to</TeX>
             </Typography>
           </Grid>
           <Grid item>
-            <Typography variant="h6">
+            <Typography variant="h6" component="div">
               iff: <TeX>\leftrightarrow</TeX>
             </Typography>
           </Grid>

--- a/src/util/buildTable.ts
+++ b/src/util/buildTable.ts
@@ -2,10 +2,6 @@ import { Column } from "react-table"
 import { evaluate, getVars, parse } from "./parser/proposition"
 import { Results } from "./parser/proposition/ast"
 
-// asciimath2tex has no type defintion
-// @ts-ignore 7016
-import AsciiMathParser from "asciimath2tex"
-
 /**
  * Genetates a boolean matrix
  *
@@ -37,7 +33,6 @@ function generateValues(vars: Array<string>) {
 }
 
 export async function buildTable(proposition: string): Promise<[Array<Column>, Array<any>]> {
-  const asciiParser = new AsciiMathParser()
   const columns: Array<Column> = []
   const data = []
 
@@ -51,7 +46,7 @@ export async function buildTable(proposition: string): Promise<[Array<Column>, A
     if (columns.length === 0) {
       for (let key of Object.keys(results)) {
         columns.push({
-          Header: asciiParser.parse(key),
+          Header: key,
           accessor: key
         })
       }

--- a/src/util/parser/proposition/grammar.ne
+++ b/src/util/parser/proposition/grammar.ne
@@ -1,20 +1,41 @@
 @preprocessor typescript
-@{%// eslint-disable-next-line import/first
-import {Atom, Paren, Not, And, Or, Xor, Implies, Iff} from './ast' %}
 
-proposition -> iff                  {% id %}
-iff         -> iff "↔" implies      {% (d) => new Iff(d[1], d[0], d[2]) %}      # IFF
-                | implies           {% id %}
-implies     -> implies "→" xor      {% (d) => new Implies(d[1], d[0], d[2]) %}  # Implies (if)
-                | xor               {% id %}
-xor         -> xor "⊕" or           {% (d) => new Xor(d[1], d[0], d[2]) %}      # Exclusive Or
-                | or                {% id %}
-or          -> or "∨" and           {% (d) => new Or(d[1], d[0], d[2]) %}       # Inclusive Or
-                | and               {% id %}
-and         -> and "∧" not          {% (d) => new And(d[1], d[0], d[2]) %}      # And
-                | not               {% id %}
-not         -> "¬" not              {% (d) => new Not(d[0], d[1], null) %}      # Negation
-                | paren             {% id %}
-paren       -> "(" proposition ")"  {% (d) => new Paren(null, d[1], null) %}    # Handle parentheses
-                | var               {% id %}
-var         -> [a-zA-Z]             {% (d) => new Atom(null, d[0], null) %}     # Var
+@{%
+// eslint-disable-next-line import/first
+import moo from 'moo'
+// eslint-disable-next-line import/first
+import {Atom, Paren, Not, And, Or, Xor, Implies, Iff} from './ast'
+%}
+
+@{%
+const lexer = moo.compile({
+  iff:      /\\leftrightarrow\b\s?/,
+  implies:  /\\to\b\s?/,
+  xor:      /\\oplus\b\s?/,
+  or:       /\\vee\b\s?/,
+  and:      /\\wedge\b\s?/,
+  not:      /\\neg\b\s?/,
+  lParen:   /\(\s?/,
+  rParen:   /\)\s?/,
+  symbol:   /[a-zA-Z]/
+})
+%}
+
+@lexer lexer
+
+proposition -> iff                          {% id %}
+iff         -> iff %iff implies             {% (d) => new Iff(d[1], d[0], d[2]) %}        # IFF
+             | implies                      {% id %}
+implies     -> implies %implies xor         {% (d) => new Implies(d[1], d[0], d[2]) %}    # Implies (if)
+             | xor                          {% id %}
+xor         -> xor %xor or                  {% (d) => new Xor(d[1], d[0], d[2]) %}        # Exclusive Or
+             | or                           {% id %}
+or          -> or %or and                   {% (d) => new Or(d[1], d[0], d[2]) %}         # Inclusive Or
+             | and                          {% id %}
+and         -> and %and not                 {% (d) => new And(d[1], d[0], d[2]) %}        # And
+             | not                          {% id %}
+not         -> %not not                     {% (d) => new Not(d[0], d[1], null) %}        # Negation
+             | paren                        {% id %}
+paren       -> %lParen proposition %rParen  {% (d) => new Paren(null, d[1], null) %}      # Handle parentheses
+             | atom                         {% id %}
+atom        -> %symbol                      {% (d) => new Atom(null, d[0].value, null) %} # Var

--- a/src/util/parser/proposition/grammar.ts
+++ b/src/util/parser/proposition/grammar.ts
@@ -2,67 +2,83 @@
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
-function id(d: any[]): any {
-  return d[0]
-}
+function id(d: any[]): any { return d[0]; }
+declare var iff: any;
+declare var implies: any;
+declare var xor: any;
+declare var or: any;
+declare var and: any;
+declare var not: any;
+declare var lParen: any;
+declare var rParen: any;
+declare var symbol: any;
+
 // eslint-disable-next-line import/first
-import { Atom, Paren, Not, And, Or, Xor, Implies, Iff } from "./ast"
+import moo from 'moo'
+// eslint-disable-next-line import/first
+import {Atom, Paren, Not, And, Or, Xor, Implies, Iff} from './ast'
+
+
+const lexer = moo.compile({
+  iff:      /\\leftrightarrow\b\s?/,
+  implies:  /\\to\b\s?/,
+  xor:      /\\oplus\b\s?/,
+  or:       /\\vee\b\s?/,
+  and:      /\\wedge\b\s?/,
+  not:      /\\neg\b\s?/,
+  lParen:   /\(\s?/,
+  rParen:   /\)\s?/,
+  symbol:   /[a-zA-Z]/
+})
+
 interface NearleyToken {
-  value: any
-  [key: string]: any
-}
+  value: any;
+  [key: string]: any;
+};
 
 interface NearleyLexer {
-  reset: (chunk: string, info: any) => void
-  next: () => NearleyToken | undefined
-  save: () => any
-  formatError: (token: never) => string
-  has: (tokenType: string) => boolean
-}
+  reset: (chunk: string, info: any) => void;
+  next: () => NearleyToken | undefined;
+  save: () => any;
+  formatError: (token: never) => string;
+  has: (tokenType: string) => boolean;
+};
 
 interface NearleyRule {
-  name: string
-  symbols: NearleySymbol[]
-  postprocess?: (d: any[], loc?: number, reject?: {}) => any
-}
+  name: string;
+  symbols: NearleySymbol[];
+  postprocess?: (d: any[], loc?: number, reject?: {}) => any;
+};
 
-type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean }
+type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
 
 interface Grammar {
-  Lexer: NearleyLexer | undefined
-  ParserRules: NearleyRule[]
-  ParserStart: string
-}
+  Lexer: NearleyLexer | undefined;
+  ParserRules: NearleyRule[];
+  ParserStart: string;
+};
 
 const grammar: Grammar = {
-  Lexer: undefined,
+  Lexer: lexer,
   ParserRules: [
-    { name: "proposition", symbols: ["iff"], postprocess: id },
-    { name: "iff", symbols: ["iff", { literal: "↔" }, "implies"], postprocess: (d) => new Iff(d[1], d[0], d[2]) },
-    { name: "iff", symbols: ["implies"], postprocess: id },
-    {
-      name: "implies",
-      symbols: ["implies", { literal: "→" }, "xor"],
-      postprocess: (d) => new Implies(d[1], d[0], d[2])
-    },
-    { name: "implies", symbols: ["xor"], postprocess: id },
-    { name: "xor", symbols: ["xor", { literal: "⊕" }, "or"], postprocess: (d) => new Xor(d[1], d[0], d[2]) },
-    { name: "xor", symbols: ["or"], postprocess: id },
-    { name: "or", symbols: ["or", { literal: "∨" }, "and"], postprocess: (d) => new Or(d[1], d[0], d[2]) },
-    { name: "or", symbols: ["and"], postprocess: id },
-    { name: "and", symbols: ["and", { literal: "∧" }, "not"], postprocess: (d) => new And(d[1], d[0], d[2]) },
-    { name: "and", symbols: ["not"], postprocess: id },
-    { name: "not", symbols: [{ literal: "¬" }, "not"], postprocess: (d) => new Not(d[0], d[1], null) },
-    { name: "not", symbols: ["paren"], postprocess: id },
-    {
-      name: "paren",
-      symbols: [{ literal: "(" }, "proposition", { literal: ")" }],
-      postprocess: (d) => new Paren(null, d[1], null)
-    },
-    { name: "paren", symbols: ["var"], postprocess: id },
-    { name: "var", symbols: [/[a-zA-Z]/], postprocess: (d) => new Atom(null, d[0], null) }
+    {"name": "proposition", "symbols": ["iff"], "postprocess": id},
+    {"name": "iff", "symbols": ["iff", (lexer.has("iff") ? {type: "iff"} : iff), "implies"], "postprocess": (d) => new Iff(d[1], d[0], d[2])},
+    {"name": "iff", "symbols": ["implies"], "postprocess": id},
+    {"name": "implies", "symbols": ["implies", (lexer.has("implies") ? {type: "implies"} : implies), "xor"], "postprocess": (d) => new Implies(d[1], d[0], d[2])},
+    {"name": "implies", "symbols": ["xor"], "postprocess": id},
+    {"name": "xor", "symbols": ["xor", (lexer.has("xor") ? {type: "xor"} : xor), "or"], "postprocess": (d) => new Xor(d[1], d[0], d[2])},
+    {"name": "xor", "symbols": ["or"], "postprocess": id},
+    {"name": "or", "symbols": ["or", (lexer.has("or") ? {type: "or"} : or), "and"], "postprocess": (d) => new Or(d[1], d[0], d[2])},
+    {"name": "or", "symbols": ["and"], "postprocess": id},
+    {"name": "and", "symbols": ["and", (lexer.has("and") ? {type: "and"} : and), "not"], "postprocess": (d) => new And(d[1], d[0], d[2])},
+    {"name": "and", "symbols": ["not"], "postprocess": id},
+    {"name": "not", "symbols": [(lexer.has("not") ? {type: "not"} : not), "not"], "postprocess": (d) => new Not(d[0], d[1], null)},
+    {"name": "not", "symbols": ["paren"], "postprocess": id},
+    {"name": "paren", "symbols": [(lexer.has("lParen") ? {type: "lParen"} : lParen), "proposition", (lexer.has("rParen") ? {type: "rParen"} : rParen)], "postprocess": (d) => new Paren(null, d[1], null)},
+    {"name": "paren", "symbols": ["atom"], "postprocess": id},
+    {"name": "atom", "symbols": [(lexer.has("symbol") ? {type: "symbol"} : symbol)], "postprocess": (d) => new Atom(null, d[0].value, null)}
   ],
-  ParserStart: "proposition"
-}
+  ParserStart: "proposition",
+};
 
-export default grammar
+export default grammar;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,11 +3243,6 @@ asap@~2.0.6:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
-asciimath2tex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/asciimath2tex/-/asciimath2tex-1.1.0.tgz#c09b720f1a602f0e6d991c302ce2e09a70a64bdc"
-  integrity sha512-peQUT7lMbtRd7FnYiiqzTofhpj9IZggvinPbqJpPYOx8FLStaXPCr4WiS8lyTXcIOCtabHMe6GrQNqKwDZ68yw==
-
 asn1.js@^5.2.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"


### PR DESCRIPTION
Previously it used ascii-math, changing this allows the removal of the asciimath2tex dependency.

Additionally, added a input label and fixed up Typographys.